### PR TITLE
xbuild/cargo: Linearize workspace detection

### DIFF
--- a/xbuild/src/cargo/config.rs
+++ b/xbuild/src/cargo/config.rs
@@ -8,9 +8,21 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn parse_from_toml(path: &Path) -> Result<Self> {
+    pub fn parse_from_toml(path: impl AsRef<Path>) -> Result<Self> {
         let contents = std::fs::read_to_string(path)?;
         Ok(toml::from_str(&contents)?)
+    }
+
+    /// Search for and open `.cargo/config.toml` in any parent of the workspace root path.
+    pub fn find_cargo_config_for_workspace(workspace: impl AsRef<Path>) -> Result<Option<Self>> {
+        let workspace = workspace.as_ref();
+        let workspace = dunce::canonicalize(workspace)?;
+        workspace
+            .ancestors()
+            .map(|dir| dir.join(".cargo/config.toml"))
+            .find(|p| p.is_file())
+            .map(Config::parse_from_toml)
+            .transpose()
     }
 }
 

--- a/xbuild/src/cargo/manifest.rs
+++ b/xbuild/src/cargo/manifest.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::Deserialize;
 use std::path::Path;
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Manifest {
     pub workspace: Option<Workspace>,
     pub package: Option<Package>,
@@ -15,12 +15,16 @@ impl Manifest {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Workspace {
+    #[serde(default)]
+    pub default_members: Vec<String>,
+    #[serde(default)]
     pub members: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Package {
     pub name: String,
     pub version: String,

--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -45,9 +45,9 @@ impl Cargo {
             .transpose()?;
 
         let search_path = manifest_path.map_or_else(
-            || std::env::current_dir().unwrap(),
-            |manifest_path| manifest_path.parent().unwrap().to_owned(),
-        );
+            || std::env::current_dir().context("Could not retrieve current directory"),
+            |manifest_path| utils::canonicalize(manifest_path.parent().unwrap()),
+        )?;
 
         // Scan the given and all parent directories for a Cargo.toml containing a workspace
         let workspace_manifest = utils::find_workspace(&search_path)?;

--- a/xbuild/src/cargo/utils.rs
+++ b/xbuild/src/cargo/utils.rs
@@ -19,7 +19,7 @@ pub fn list_rust_files(dir: &Path) -> Result<Vec<String>> {
     Ok(files)
 }
 
-fn canonicalize(mut path: &Path) -> Result<PathBuf> {
+pub fn canonicalize(mut path: &Path) -> Result<PathBuf> {
     if path == Path::new("") {
         path = Path::new(".");
     }

--- a/xbuild/src/cargo/utils.rs
+++ b/xbuild/src/cargo/utils.rs
@@ -19,6 +19,14 @@ pub fn list_rust_files(dir: &Path) -> Result<Vec<String>> {
     Ok(files)
 }
 
+fn canonicalize(mut path: &Path) -> Result<PathBuf> {
+    if path == Path::new("") {
+        path = Path::new(".");
+    }
+    dunce::canonicalize(path)
+        .with_context(|| format!("Failed to canonicalize `{}`", path.display()))
+}
+
 /// Tries to find a package by the given `name` in the [workspace root] or member
 /// of the given [workspace] [`Manifest`].
 ///
@@ -85,7 +93,7 @@ pub fn find_package_manifest_in_workspace(
 /// When a workspace has been detected, use [`find_package_manifest_in_workspace()`] to find packages
 /// instead (that are members of the given workspace) when the user specified a package name (with `-p`).
 pub fn find_package_manifest(path: &Path, name: Option<&str>) -> Result<(PathBuf, Manifest)> {
-    let path = dunce::canonicalize(path)?;
+    let path = canonicalize(path)?;
     let manifest_path = path
         .ancestors()
         .map(|dir| dir.join("Cargo.toml"))

--- a/xbuild/src/cargo/utils.rs
+++ b/xbuild/src/cargo/utils.rs
@@ -1,6 +1,7 @@
 use super::config::Config;
 use super::manifest::Manifest;
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
@@ -27,6 +28,12 @@ pub fn canonicalize(mut path: &Path) -> Result<PathBuf> {
         .with_context(|| format!("Failed to canonicalize `{}`", path.display()))
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PackageSelector<'a> {
+    ByName(&'a str),
+    ByPath(&'a Path),
+}
+
 /// Tries to find a package by the given `name` in the [workspace root] or member
 /// of the given [workspace] [`Manifest`].
 ///
@@ -37,61 +44,111 @@ pub fn canonicalize(mut path: &Path) -> Result<PathBuf> {
 pub fn find_package_manifest_in_workspace(
     workspace_manifest_path: &Path,
     workspace_manifest: &Manifest,
-    name: &str,
+    selector: PackageSelector<'_>,
 ) -> Result<(PathBuf, Manifest)> {
     let workspace = workspace_manifest
         .workspace
         .as_ref()
         .context("The provided Cargo.toml does not contain a `[workspace]`")?;
-
-    // Check if the workspace manifest also contains a [package]
-    if let Some(package) = &workspace_manifest.package {
-        if package.name == name {
-            return Ok((
-                workspace_manifest_path.to_owned(),
-                workspace_manifest.clone(),
-            ));
-        }
-    }
-
-    // Check all member packages inside the workspace
     let workspace_root = workspace_manifest_path.parent().unwrap();
-    for member in &workspace.members {
-        for manifest_dir in glob::glob(workspace_root.join(member).to_str().unwrap())? {
-            let manifest_path = manifest_dir?.join("Cargo.toml");
-            let manifest = Manifest::parse_from_toml(&manifest_path)?;
 
-            // Workspace members cannot themselves be/contain a new workspace
-            anyhow::ensure!(
-                manifest.workspace.is_none(),
-                "Did not expect a `[workspace]` at `{}`",
-                manifest_path.display(),
-            );
-
-            if let Some(package) = &manifest.package {
+    match selector {
+        PackageSelector::ByName(name) => {
+            // Check if the workspace manifest also contains a [package]
+            if let Some(package) = &workspace_manifest.package {
                 if package.name == name {
-                    return Ok((manifest_path, manifest));
+                    return Ok((
+                        workspace_manifest_path.to_owned(),
+                        workspace_manifest.clone(),
+                    ));
                 }
+            }
+
+            // Check all member packages inside the workspace
+            for member in &workspace.members {
+                for manifest_dir in glob::glob(workspace_root.join(member).to_str().unwrap())? {
+                    let manifest_path = manifest_dir?.join("Cargo.toml");
+                    let manifest =
+                        Manifest::parse_from_toml(&manifest_path).with_context(|| {
+                            format!(
+                                "Failed to load manifest for workspace member `{}`",
+                                manifest_path.display()
+                            )
+                        })?;
+
+                    // Workspace members cannot themselves be/contain a new workspace
+                    anyhow::ensure!(
+                        manifest.workspace.is_none(),
+                        "Did not expect a `[workspace]` at `{}`",
+                        manifest_path.display(),
+                    );
+
+                    if let Some(package) = &manifest.package {
+                        if package.name == name {
+                            return Ok((manifest_path, manifest));
+                        }
+                    } else {
+                        anyhow::bail!(
+                            "Failed to parse manifest at `{}`: virtual manifests must be configured with `[workspace]`",
+                            manifest_path.display(),
+                        );
+                    }
+                }
+            }
+
+            Err(anyhow::anyhow!(
+                "package `{}` not found in workspace `{}`",
+                workspace_manifest_path.display(),
+                name,
+            ))
+        }
+        PackageSelector::ByPath(path) => {
+            let path = canonicalize(path)?;
+            let workspace_root = canonicalize(workspace_root)?;
+
+            // Check all member packages inside the workspace
+            let mut all_members = HashSet::new();
+
+            for member in &workspace.members {
+                for manifest_dir in glob::glob(workspace_root.join(member).to_str().unwrap())? {
+                    let manifest_path = manifest_dir?.join("Cargo.toml");
+                    let manifest =
+                        Manifest::parse_from_toml(&manifest_path).with_context(|| {
+                            format!(
+                                "Failed to load manifest for workspace member `{}`",
+                                manifest_path.display()
+                            )
+                        })?;
+
+                    // Workspace members cannot themselves be/contain a new workspace
+                    anyhow::ensure!(
+                        manifest.workspace.is_none(),
+                        "Did not expect a `[workspace]` at `{}`",
+                        manifest_path.display(),
+                    );
+                    all_members.insert(manifest_path);
+                }
+            }
+
+            // Find the closest member based on the given path
+            if let Some(manifest_dir) = path.ancestors().find(|&dir| all_members.contains(dir)) {
+                let manifest_path = manifest_dir.join("Cargo.toml");
+                let manifest = Manifest::parse_from_toml(&manifest_path)?;
+                Ok((manifest_path, manifest))
             } else {
-                anyhow::bail!(
-                    "Failed to parse manifest at `{}`: virtual manifests must be configured with `[workspace]`",
-                    manifest_path.display(),
-                );
+                Ok((
+                    workspace_manifest_path.to_owned(),
+                    workspace_manifest.clone(),
+                ))
             }
         }
     }
-
-    Err(anyhow::anyhow!(
-        "package `{}` not found in workspace `{}`",
-        workspace_manifest_path.display(),
-        name,
-    ))
 }
 
 /// Recursively walk up the directories until finding a `Cargo.toml`
 ///
 /// When a workspace has been detected, use [`find_package_manifest_in_workspace()`] to find packages
-/// instead (that are members of the given workspace) when the user specified a package name (with `-p`).
+/// instead (that are members of the given workspace).
 pub fn find_package_manifest(path: &Path, name: Option<&str>) -> Result<(PathBuf, Manifest)> {
     let path = canonicalize(path)?;
     let manifest_path = path

--- a/xbuild/src/gradle/mod.rs
+++ b/xbuild/src/gradle/mod.rs
@@ -14,7 +14,7 @@ pub fn prepare(env: &BuildEnv) -> Result<()> {
         let package = config.manifest.package.as_ref().unwrap();
         let wry = env.platform_dir().join("wry");
         std::fs::create_dir_all(&wry)?;
-        if !env.cargo().root_dir().join("kotlin").exists() {
+        if !env.cargo().package_root().join("kotlin").exists() {
             let main_activity = format!(
                 r#"
                     package {}
@@ -101,7 +101,7 @@ pub fn build(env: &BuildEnv, apk: &Path) -> Result<()> {
     )?;
 
     let srcs = [
-        env.cargo().root_dir().join("kotlin"),
+        env.cargo().package_root().join("kotlin"),
         env.platform_dir().join("wry"),
     ];
     for src in srcs {


### PR DESCRIPTION
Import cargo workspace changes from cargo-subcommand in preparation for workspace inheritance.

This effectively synchronizes us with:

https://github.com/dvc94ch/cargo-subcommand/pull/23
https://github.com/dvc94ch/cargo-subcommand/pull/24
https://github.com/dvc94ch/cargo-subcommand/pull/25
(and a tiny initial bit of https://github.com/dvc94ch/cargo-subcommand/pull/12)

@dvc94ch the changes from https://github.com/dvc94ch/cargo-subcommand/pull/25 are still WIP, would you mind checking them out with me (see TODOs) and deciding where to go next?
