### PR TITLE
Inherit package configuration (`version` and `description`) from workspace root

### DIFF
--- a/xbuild/src/cargo/manifest.rs
+++ b/xbuild/src/cargo/manifest.rs
@@ -2,6 +2,13 @@ use anyhow::Result;
 use serde::Deserialize;
 use std::path::Path;
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum Inheritable<T> {
+    Value(T),
+    Inherited { workspace: bool },
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Manifest {
     pub workspace: Option<Workspace>,
@@ -22,11 +29,21 @@ pub struct Workspace {
     pub default_members: Vec<String>,
     #[serde(default)]
     pub members: Vec<String>,
+
+    pub package: Option<WorkspacePackage>,
+}
+
+/// Almost the same as [`Package`], except that this must provide
+/// root values instead of possibly inheritable values
+#[derive(Clone, Debug, Deserialize)]
+pub struct WorkspacePackage {
+    pub version: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Package {
     pub name: String,
-    pub version: String,
-    pub description: Option<String>,
+    pub version: Inheritable<String>,
+    pub description: Option<Inheritable<String>>,
 }

--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -17,7 +17,7 @@ use crate::{CompileTarget, Opt};
 pub struct Cargo {
     package: String,
     features: Vec<String>,
-    _workspace_manifest: Option<Manifest>,
+    workspace_manifest: Option<Manifest>,
     manifest: Manifest,
     package_root: PathBuf,
     target_dir: PathBuf,
@@ -106,7 +106,7 @@ impl Cargo {
         Ok(Self {
             package: package.clone(),
             features,
-            _workspace_manifest: workspace_manifest.map(|(_path, manifest)| manifest),
+            workspace_manifest: workspace_manifest.map(|(_path, manifest)| manifest),
             manifest,
             package_root: package_root.to_owned(),
             target_dir,
@@ -120,6 +120,10 @@ impl Cargo {
 
     pub fn package(&self) -> &str {
         &self.package
+    }
+
+    pub fn workspace_manifest(&self) -> Option<&Manifest> {
+        self.workspace_manifest.as_ref()
     }
 
     pub fn manifest(&self) -> &Manifest {

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -583,11 +583,10 @@ impl BuildEnv {
         let build_target = args.build_target.build_target()?;
         let build_dir = cargo.target_dir().join("x");
         let cache_dir = dirs::cache_dir().unwrap().join("x");
-        let cargo_manifest = cargo.manifest();
-        let package = cargo_manifest.package.as_ref().unwrap(); // Caller should guarantee that this is a valid package
+        let package = cargo.manifest().package.as_ref().unwrap(); // Caller should guarantee that this is a valid package
         let manifest = cargo.package_root().join("manifest.yaml");
         let mut config = Config::parse(&manifest)?;
-        config.apply_rust_package(package, build_target.opt());
+        config.apply_rust_package(package, cargo.workspace_manifest(), build_target.opt())?;
         let icon = config
             .icon(build_target.platform())
             .map(|icon| cargo.package_root().join(icon));


### PR DESCRIPTION
Depends on #83

Starting with [Rust 1.64] common `[package]` parameters (and dependencies) can now be specified in the workspace root manifest by setting `<field>.workspace=true` in a `[package]` and specifying its value in the workspace root manifest under [`[workspace.package]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacepackage-table).

Since `xbuild` reads the `version` and `description` field from `[package]` it has to support this new format and pull the values from the root manifest instead, in order to support projects utilizing this new format.

This is currently implemented ad-hoc for the version and description field, but could be done in a cleaner way if/when more fields are needed.

[Rust 1.64]: https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds
