### PR TITLE
xbuild: Add `-r` shorthand for `--release`

### DIFF
--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -348,7 +348,7 @@ pub struct CargoArgs {
     #[clap(long)]
     offline: bool,
     /// Space or comma separated list of features to activate
-    #[clap(short = 'F', long)]
+    #[clap(long, short = 'F')]
     features: Vec<String>,
 }
 
@@ -370,7 +370,7 @@ pub struct BuildTargetArgs {
     #[clap(long, conflicts_with = "release")]
     debug: bool,
     /// Build artifacts in release mode, with optimizations
-    #[clap(long, conflicts_with = "debug")]
+    #[clap(long, short, conflicts_with = "debug")]
     release: bool,
     /// Build artifacts for target platform. Can be one of
     /// `android`, `ios`, `linux`, `macos` or `windows`.


### PR DESCRIPTION
Despite these arguments not being specific to match `cargo`, having a similar short-hand is nice.
