### PR TITLE
Fix Rust 1.66 clippy lints including `clippy::unused_format_specs`

### DIFF
--- a/apk/src/compiler/xml.rs
+++ b/apk/src/compiler/xml.rs
@@ -141,7 +141,7 @@ fn compile_node(
             class_index,
             style_index,
         },
-        attrs.into_iter().map(|(_, v)| v).collect(),
+        attrs.into_values().collect(),
     ));
     /*let mut children = BTreeMap::new();
     for node in node.children() {

--- a/xbuild/src/command/mod.rs
+++ b/xbuild/src/command/mod.rs
@@ -25,7 +25,7 @@ pub fn devices() -> Result<()> {
             "{:50}{:20}{:20}{}",
             device.to_string(),
             device.name()?,
-            format_args!("{} {}", device.platform()?, device.arch()?),
+            format!("{} {}", device.platform()?, device.arch()?),
             device.details()?,
         );
     }

--- a/xbuild/src/download.rs
+++ b/xbuild/src/download.rs
@@ -55,7 +55,7 @@ impl<'a> DownloadManager<'a> {
     pub fn new(env: &'a BuildEnv) -> Result<Self> {
         let client = Client::new();
         let download_dir = env.cache_dir().join("download");
-        std::fs::create_dir_all(&download_dir)?;
+        std::fs::create_dir_all(download_dir)?;
         Ok(Self { env, client })
     }
 

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -589,7 +589,7 @@ impl BuildEnv {
         let cache_dir = dirs::cache_dir().unwrap().join("x");
         let package = cargo.manifest().package.as_ref().unwrap(); // Caller should guarantee that this is a valid package
         let manifest = cargo.package_root().join("manifest.yaml");
-        let mut config = Config::parse(&manifest)?;
+        let mut config = Config::parse(manifest)?;
         config.apply_rust_package(package, cargo.workspace_manifest(), build_target.opt())?;
         let icon = config
             .icon(build_target.platform())

--- a/xcommon/src/lib.rs
+++ b/xcommon/src/lib.rs
@@ -252,7 +252,7 @@ fn find_cde_start_pos<R: Read + Seek>(reader: &mut R) -> Result<u64> {
     anyhow::ensure!(file_length >= HEADER_SIZE, "Invalid zip header");
     let mut pos = file_length - HEADER_SIZE;
     while pos >= search_upper_bound {
-        reader.seek(SeekFrom::Start(pos as u64))?;
+        reader.seek(SeekFrom::Start(pos))?;
         if reader.read_u32::<LittleEndian>()? == CENTRAL_DIRECTORY_END_SIGNATURE {
             return Ok(pos);
         }


### PR DESCRIPTION
`clippy::unused_format_specs` pointed out that we were actually concatenating `device.arch()` to `device.details()` because alignment args don't apply to nested `format_args!` invocations.

For example, see how the last two columns are concatenated instead of aligned (alignment shortened for brevity elsewhere):

    host            Linux   linux x64Arch Linux 6.0.12-arch1-1
    adb:mydeviceid  b0s     android arm64Android 13 (API 33)
