### PR TITLE
appbundle: Switch to released `apple-codesign 0.21.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ members = [
 ]
 default-members = ["xbuild"]
 exclude = ["examples"]
-
-[patch.crates-io]
-apple-codesign = { git = "https://github.com/indygreg/apple-platform-rs", branch = "main" }

--- a/appbundle/Cargo.toml
+++ b/appbundle/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 anyhow = "1.0.65"
-apple-codesign = "0.20.1-pre"
+apple-codesign = "0.21.0"
 icns = "0.3.1"
 log = "0.4.17"
 pkcs8 = "0.9.0"

--- a/xbuild/template/Cargo.toml
+++ b/xbuild/template/Cargo.toml
@@ -14,7 +14,8 @@ dioxus = "0.2.4"
 dioxus-desktop = "0.2.3"
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.11.1"
+# Locked until https://github.com/Nercury/android_logger-rs/issues/58 is fixed
+android_logger = "=0.11.1"
 log = "0.4.17"
 ndk-context = "0.1.1"
 paste = "1.0.9"


### PR DESCRIPTION
`0.20.1-pre` appears to be unpublished, making `xbuild` not compile anymore unless switching to the released `0.21.0` version, allowing us to drop the git patch too.
