### PR TITLE
chore: remove wry dependency from template

### DIFF
--- a/xbuild/template/Cargo.toml
+++ b/xbuild/template/Cargo.toml
@@ -19,7 +19,6 @@ android_logger = "=0.11.1"
 log = "0.4.17"
 ndk-context = "0.1.1"
 paste = "1.0.9"
-wry = "0.22.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 console_error_panic_hook = "0.1.7"

--- a/xbuild/template/lib.rs
+++ b/xbuild/template/lib.rs
@@ -3,15 +3,13 @@ use dioxus::prelude::*;
 #[cfg(target_os = "android")]
 #[no_mangle]
 pub extern "C" fn start_app() {
-    use wry::android_binding;
-
     android_logger::init_once(
         android_logger::Config::default()
             .with_min_level(log::Level::Trace)
             .with_tag("template"),
     );
 
-    android_binding!(com_example, template, _start_app);
+    dioxus_desktop::wry::android_binding!(com_example, template, _start_app, dioxus_desktop::wry);
 }
 
 #[cfg(target_os = "android")]


### PR DESCRIPTION
Use the re-exported `wry` from `dioxus-desktop` to avoid possible conflict in case of deps upgrade.