### PR TITLE
Append `runtime_libs` specified in manifest to APK

### DIFF
--- a/xcommon/src/llvm.rs
+++ b/xcommon/src/llvm.rs
@@ -2,34 +2,23 @@
 
 use anyhow::{bail, ensure, Context, Result};
 use std::collections::HashSet;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Returns the set of additional libraries that need to be bundled with
 /// the given library, scanned recursively.
 ///
-/// Any libraries in `provided_libs_paths` will be treated as available, without
-/// being emitted. Any other library not in `search_paths` or `provided_libs_paths`
+/// Any libraries in `provided_libs` will be treated as available, without
+/// being emitted. Any other library not in `search_paths` or `provided_libs`
 /// will result in an error.
 pub fn list_needed_libs_recursively(
     lib: &Path,
     search_paths: &[&Path],
-    provided_libs_paths: &[&Path],
-) -> Result<HashSet<PathBuf>> {
-    // Create a view of all libraries that are available on Android
-    let mut provided = HashSet::new();
-    for path in provided_libs_paths {
-        for lib in find_libs_in_dir(path).with_context(|| {
-            format!("Unable to list available libraries in `{}`", path.display())
-        })? {
-            // libc++_shared is bundled with the NDK but not available on-device
-            if lib != "libc++_shared.so" {
-                provided.insert(lib);
-            }
-        }
-    }
-
+    provided_libs: &HashSet<OsString>,
+) -> Result<(HashSet<PathBuf>, bool)> {
     let mut to_copy = HashSet::new();
+    let mut needs_cpp_shared = false;
 
     let mut artifacts = vec![lib.to_path_buf()];
     while let Some(artifact) = artifacts.pop() {
@@ -39,16 +28,11 @@ pub fn list_needed_libs_recursively(
                 artifact.display()
             )
         })? {
-            // c++_shared is available in the NDK but not on-device.
-            // Must be bundled with the apk if used:
-            // https://developer.android.com/ndk/guides/cpp-support#libc
-            let search_paths = if need == "libc++_shared.so" {
-                provided_libs_paths
-            } else {
-                search_paths
-            };
-
-            if provided.insert(need.clone()) {
+            if need == "libc++_shared.so" {
+                // c++_shared is available in the NDK but not on-device. Communicate that
+                //  we need to copy it, once
+                needs_cpp_shared = true;
+            } else if !provided_libs.contains(OsStr::new(&need)) {
                 if let Some(path) = find_library_path(search_paths, &need).with_context(|| {
                     format!(
                         "Could not iterate one or more search directories in `{:?}` while searching for library `{}`",
@@ -64,7 +48,7 @@ pub fn list_needed_libs_recursively(
         }
     }
 
-    Ok(to_copy)
+    Ok((to_copy, needs_cpp_shared))
 }
 
 /// List all required shared libraries as per the dynamic section
@@ -93,17 +77,14 @@ fn list_needed_libs(library_path: &Path) -> Result<HashSet<String>> {
 }
 
 /// List names of shared libraries inside directory
-fn find_libs_in_dir(path: &Path) -> Result<HashSet<String>> {
+pub fn find_libs_in_dir(path: &Path) -> Result<HashSet<OsString>> {
     let mut libs = HashSet::new();
     let entries = std::fs::read_dir(path)?;
     for entry in entries {
         let entry = entry?;
-        if !entry.path().is_dir() {
-            if let Some(file_name) = entry.file_name().to_str() {
-                if file_name.ends_with(".so") {
-                    libs.insert(file_name.to_string());
-                }
-            }
+        let path = entry.path();
+        if !path.is_dir() && path.extension() == Some(OsStr::new("so")) {
+            libs.insert(entry.file_name().to_owned());
         }
     }
     Ok(libs)


### PR DESCRIPTION
Certain apps and crates `dlopen` libraries at runtime (which are not listed in the shared library table by design, hence not found by `llvm-readobj`).  Facilitate this by allowing the user to specify a list of folders that need to be scanned for libraries to include in the final package at while building.  This folder structure includes the platform ABI to select the desired shared libraries.
