### PR TITLE
adb: Don't ignore remote exit codes

### DIFF
--- a/xbuild/src/devices/adb.rs
+++ b/xbuild/src/devices/adb.rs
@@ -35,7 +35,7 @@ impl Adb {
 
     fn shell(&self, device: &str, run_as: Option<&str>) -> Command {
         let mut cmd = self.adb(device);
-        cmd.arg("shell").arg("-x");
+        cmd.arg("shell");
         if let Some(package) = run_as {
             cmd.arg("run-as").arg(package);
         }


### PR DESCRIPTION
Besides disabling stdout/stderr separation (effectively merging them together), `-x` ignores remote exit codes meaning failures in shell commands don't get propagated and don't fail the invocation.
