### PR TITLE
fix: use `gradle.bat` on Windows

### DIFF
--- a/xbuild/src/gradle/mod.rs
+++ b/xbuild/src/gradle/mod.rs
@@ -157,6 +157,9 @@ pub fn build(env: &BuildEnv, out: &Path) -> Result<()> {
 
     let opt = env.target().opt();
     let format = env.target().format();
+    #[cfg(windows)]
+    let mut cmd = Command::new("gradle.bat");
+    #[cfg(not(windows))]
     let mut cmd = Command::new("gradle");
     cmd.current_dir(&gradle);
     cmd.arg(match format {


### PR DESCRIPTION
I am not sure if the bootstrapped template should have the `gradlew` binaries or not but I didn't find one there so I added `gradlew` to `PATH` but it couldn't be picked up by `std::process::Command` unless `gradlew.bat` is used.