### PR TITLE
apk/manifest: Add `android:colorMode` attribute to `Activity`

### DIFF
--- a/apk/src/manifest.rs
+++ b/apk/src/manifest.rs
@@ -111,6 +111,8 @@ pub struct Activity {
     #[serde(rename(serialize = "intent-filter"))]
     #[serde(default)]
     pub intent_filters: Vec<IntentFilter>,
+    #[serde(rename(serialize = "android:colorMode"))]
+    pub color_mode: Option<String>,
 }
 
 /// Android [intent filter element](https://developer.android.com/guide/topics/manifest/intent-filter-element).


### PR DESCRIPTION
This currently only has 3 predefined values, and will be converted to an integer (enum) by the resource compiler:

https://developer.android.com/reference/android/R.attr#colorMode
https://developer.android.com/guide/topics/manifest/activity-element#colormode
