### PR TITLE
Allow setting `--format` when building for / running on a `--device`

### DIFF
--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -386,12 +386,12 @@ pub struct BuildTargetArgs {
     arch: Option<Arch>,
     /// Build artifacts for target device. To find the device
     /// identifier of a connected device run `x devices`.
-    #[clap(long, conflicts_with = "format", conflicts_with = "store")]
+    #[clap(long, conflicts_with = "store")]
     device: Option<Device>,
     /// Build artifacts with format. Can be one of `aab`,
     /// `apk`, `appbundle`, `appdir`, `appimage`, `dmg`,
     /// `exe`, `ipa`, `msix`.
-    #[clap(long, conflicts_with = "device", conflicts_with = "store")]
+    #[clap(long, conflicts_with = "store")]
     format: Option<Format>,
     /// Build artifacts for target app store. Can be one of
     /// `apple`, `microsoft`, `play` or `sideload`.


### PR DESCRIPTION
It should be perfectly sensible to switch between `aab` and `apk` formats while still using `--device` to build for and install the resulting package on a specific connected device.

Additionally we could look at Clap's argument groups to properly convey mutual-exclusivity between `--store`, `--device` and `--arch`+`--platform`.  It is of course true that this `--format` argument has _some_ dependencies/limitations on all those flags too (i.e. when `--device` specifies Android, `--format` must be `apk` or `aab`), but that might be too complicated to represent in Clap.
