### PR TITLE
adb: Pass `-W` (wait for app start) to `am start` before getting `pidof`

### DIFF
--- a/xbuild/src/devices/adb.rs
+++ b/xbuild/src/devices/adb.rs
@@ -97,6 +97,7 @@ impl Adb {
             .shell(device, None)
             .arg("am")
             .arg("start")
+            .arg("-W")
             .arg("-a")
             .arg("android.intent.action.MAIN")
             .arg("-n")
@@ -184,7 +185,7 @@ impl Adb {
             );
             let pid = std::str::from_utf8(&output.stdout)?.trim();
             // may return multiple space separated pids if the old process hasn't exited yet.
-            if pid.is_empty() || pid.split_once(' ').is_some() {
+            if pid.is_empty() || pid.contains(' ') {
                 std::thread::sleep(std::time::Duration::from_millis(100));
                 continue;
             }


### PR DESCRIPTION
Sometimes the app hasn't started yet, and `xbuild` fails with:

    Error: failed to get pid:

because `pidof` could not find any process with that name, and exits with a non-zero error code (and stderr is left empty).  Simply passing `-W` to make `am start` block a little while longer until the app is actually running seems to resolve this issue in the common case.
