### PR TITLE
Fix unused `Permissions` import lint warning on Windows

### DIFF
--- a/appimage/src/lib.rs
+++ b/appimage/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::fs::{File, Permissions};
+use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -95,7 +95,7 @@ impl AppImage {
         let mut squashfs = BufReader::new(File::open(squashfs)?);
         let mut f = File::create(out)?;
         #[cfg(unix)]
-        f.set_permissions(Permissions::from_mode(0o755))?;
+        f.set_permissions(std::fs::Permissions::from_mode(0o755))?;
         let mut out = BufWriter::new(&mut f);
         out.write_all(RUNTIME)?;
         std::io::copy(&mut squashfs, &mut out)?;

--- a/xcommon/src/lib.rs
+++ b/xcommon/src/lib.rs
@@ -8,7 +8,7 @@ use image::{DynamicImage, GenericImageView, ImageOutputFormat, RgbaImage};
 use rsa::pkcs8::DecodePrivateKey;
 use rsa::{PaddingScheme, RsaPrivateKey, RsaPublicKey};
 use sha2::{Digest, Sha256};
-use std::fs::{File, OpenOptions, Permissions};
+use std::fs::{File, OpenOptions};
 use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use zip::write::FileOptions;
@@ -450,7 +450,7 @@ pub fn extract_zip(archive: &Path, directory: &Path) -> Result<()> {
                 {
                     use std::os::unix::fs::PermissionsExt;
                     if let Some(mode) = file.unix_mode() {
-                        std::fs::set_permissions(&outpath, Permissions::from_mode(mode))?;
+                        std::fs::set_permissions(&outpath, std::fs::Permissions::from_mode(mode))?;
                     }
                 }
             }


### PR DESCRIPTION
The use of this type is behind a `cfg(unix)`, resulting in unused imports on Windows.

Perhaps we should adjust the CI to obstruct merging on clippy lints on any platform?
