### PR TITLE
apk: Embed configurable assets in `asset/` directory

### DIFF
--- a/msix/src/lib.rs
+++ b/msix/src/lib.rs
@@ -73,8 +73,13 @@ impl Msix {
         self.zip.add_file(source, dest, opts)
     }
 
-    pub fn add_directory(&mut self, source: &Path, dest: &Path) -> Result<()> {
-        self.zip.add_directory(source, dest)
+    pub fn add_directory(
+        &mut self,
+        source: &Path,
+        dest: &Path,
+        opts: ZipFileOptions,
+    ) -> Result<()> {
+        self.zip.add_directory(source, dest, opts)
     }
 
     pub fn finish(mut self, signer: Option<Signer>) -> Result<()> {

--- a/xbuild/src/command/build.rs
+++ b/xbuild/src/command/build.rs
@@ -83,6 +83,14 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                 )?;
                 apk.add_res(env.icon(), &env.android_jar())?;
 
+                for asset in &env.config().android().assets {
+                    let path = env.cargo().package_root().join(asset.path());
+
+                    if !asset.optional() || path.exists() {
+                        apk.add_asset(&path, asset.alignment().to_zip_file_options())?
+                    }
+                }
+
                 if has_lib {
                     for target in env.target().compile_targets() {
                         let arch_dir = platform_dir.join(target.arch().to_string());
@@ -256,6 +264,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                 ipa.add_directory(
                     &app,
                     &Path::new("Payload").join(format!("{}.app", env.name())),
+                    ZipFileOptions::Compressed,
                 )?;
                 ipa.finish()?;
             }

--- a/xcommon/src/lib.rs
+++ b/xcommon/src/lib.rs
@@ -286,14 +286,20 @@ impl Zip {
     }
 
     pub fn add_file(&mut self, source: &Path, dest: &Path, opts: ZipFileOptions) -> Result<()> {
-        let mut f = File::open(source)?;
+        let mut f = File::open(source)
+            .with_context(|| format!("While opening file `{}`", source.display()))?;
         self.start_file(dest, opts)?;
         std::io::copy(&mut f, &mut self.zip)?;
         Ok(())
     }
 
-    pub fn add_directory(&mut self, source: &Path, dest: &Path) -> Result<()> {
-        add_recursive(self, source, dest)?;
+    pub fn add_directory(
+        &mut self,
+        source: &Path,
+        dest: &Path,
+        opts: ZipFileOptions,
+    ) -> Result<()> {
+        add_recursive(self, source, dest, opts)?;
         Ok(())
     }
 
@@ -335,17 +341,19 @@ impl Zip {
     }
 }
 
-fn add_recursive(zip: &mut Zip, source: &Path, dest: &Path) -> Result<()> {
-    for entry in std::fs::read_dir(source)? {
+fn add_recursive(zip: &mut Zip, source: &Path, dest: &Path, opts: ZipFileOptions) -> Result<()> {
+    for entry in std::fs::read_dir(source)
+        .with_context(|| format!("While reading directory `{}`", source.display()))?
+    {
         let entry = entry?;
         let file_name = entry.file_name();
         let source = source.join(&file_name);
         let dest = dest.join(&file_name);
         let file_type = entry.file_type()?;
         if file_type.is_dir() {
-            add_recursive(zip, &source, &dest)?;
+            add_recursive(zip, &source, &dest, opts)?;
         } else if file_type.is_file() {
-            zip.add_file(&source, &dest, ZipFileOptions::Compressed)?;
+            zip.add_file(&source, &dest, opts)?;
         }
     }
     Ok(())


### PR DESCRIPTION
Fixes #82 

Android apps might want to ship with extra files - assets - to complement the native build.  These could be single files or folders that are included recursively.  the `file_name()` of the given path is added directly to the `assets/` directory, and any directory structure beyond that point is maintained.

Assets are specified in the following way in `manifest.yaml`:

```yaml
android:
  assets:
    - some/path
    - { path: some/path } # Same as above
    - { path: some/path, optional: true } # Do not error if this  path doesn't exist
    - { path: some/path, alignment: 4096 } # Page-aligned for optimal use with AASSET_MODE_BUFFER and AAsset_getBuffer
    - { path: some/path, alignment: unaligned }
    - { path: some/path, alignment: compressed }
```
