### PR TITLE
Configure `adb forward` and `adb reverse` for `x run`

### DIFF
--- a/xbuild/src/config.rs
+++ b/xbuild/src/config.rs
@@ -6,6 +6,7 @@ use apk::VersionCode;
 use appbundle::InfoPlist;
 use msix::AppxManifest;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug, Default)]
@@ -331,6 +332,16 @@ pub struct GenericConfig {
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
+pub struct AndroidDebugConfig {
+    /// Forward remote (phone) socket connection to local (host)
+    #[serde(default)]
+    pub forward: HashMap<String, String>,
+    /// Forward local (host) socket connection to remote (phone)
+    #[serde(default)]
+    pub reverse: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct AndroidConfig {
     #[serde(flatten)]
     generic: GenericConfig,
@@ -342,6 +353,9 @@ pub struct AndroidConfig {
     pub gradle: bool,
     #[serde(default)]
     pub wry: bool,
+    /// Debug configuration for `x run`
+    #[serde(default)]
+    pub debug: AndroidDebugConfig,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/xbuild/src/devices/mod.rs
+++ b/xbuild/src/devices/mod.rs
@@ -112,7 +112,7 @@ impl Device {
 
     pub fn run(&self, env: &BuildEnv, path: &Path) -> Result<()> {
         match &self.backend {
-            Backend::Adb(adb) => adb.run(&self.id, path, false),
+            Backend::Adb(adb) => adb.run(&self.id, path, &env.config.android().debug, false),
             Backend::Host(host) => host.run(path),
             Backend::Imd(imd) => imd.run(env, &self.id, path),
         }?;


### PR DESCRIPTION
Just like a similar PR for `cargo-apk` we'd like to set up some port forwarding to/from a debug phone automatically while using `x run`.  This allows configuring a mapping of ports under the `debug:` section of `android:` in `manifest.yaml`.
