### PR TITLE
Support the x86_64-linux-android build target.

### DIFF
--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -295,7 +295,9 @@ impl CargoBuild {
             target_sdk_version
         );
         self.use_ld("lld");
-        self.add_link_arg(&format!("--target={}", self.triple.unwrap_or(ndk_triple)));
+        if let Some(triple) = self.triple {
+            self.add_link_arg(&format!("--target={}", triple));
+        }
         self.add_link_arg(&format!("-B{}", sdk_lib_dir.display()));
         self.add_link_arg(&format!("-L{}", sdk_lib_dir.display()));
         self.add_link_arg(&format!("-L{}", lib_dir.display()));

--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -295,7 +295,7 @@ impl CargoBuild {
             target_sdk_version
         );
         self.use_ld("lld");
-        self.add_link_arg(&format!("--target={}", ndk_triple));
+        self.add_link_arg(&format!("--target={}", self.triple.unwrap_or(ndk_triple)));
         self.add_link_arg(&format!("-B{}", sdk_lib_dir.display()));
         self.add_link_arg(&format!("-L{}", sdk_lib_dir.display()));
         self.add_link_arg(&format!("-L{}", lib_dir.display()));

--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -295,7 +295,7 @@ impl CargoBuild {
             target_sdk_version
         );
         self.use_ld("lld");
-        self.add_link_arg("--target=aarch64-linux-android");
+        self.add_link_arg(&format!("--target={}", ndk_triple));
         self.add_link_arg(&format!("-B{}", sdk_lib_dir.display()));
         self.add_link_arg(&format!("-L{}", sdk_lib_dir.display()));
         self.add_link_arg(&format!("-L{}", lib_dir.display()));


### PR DESCRIPTION
Installs rustup targets for all targeted android architectures, not just Arch::Arm64.

Changes clang link phase --target parameter to match the build target triple.

resolves #126

