### PR TITLE
doctor: Split version str with `.lines()` to account for Windows' `\r\n`

### DIFF
--- a/xbuild/src/command/doctor.rs
+++ b/xbuild/src/command/doctor.rs
@@ -146,7 +146,7 @@ impl Check {
                 .output()?;
             anyhow::ensure!(output.status.success(), "failed to run {}", self.name);
             let output = std::str::from_utf8(&output.stdout)?;
-            if let Some(line) = output.split('\n').nth(version.row as _) {
+            if let Some(line) = output.lines().nth(version.row as _) {
                 let mut col = version.col as usize;
                 if line.starts_with("Apple ") || line.starts_with("Homebrew ") {
                     col += 1;


### PR DESCRIPTION
Excerpt from https://github.com/rust-mobile/xbuild/pull/116#discussion_r1297423973

On Windows at least `adb` prints it version string with carriage return; leaving the `\r` in there (by only splitting on `\n`) and not trimming the string causes us to print its version with a `\r` at the end, clearing the whole line (i.e. it would print `adb     1.0.41\r` followed by the path, and then only the path remains on this line).

Rust's `.lines()` implementation already takes care of this by splitting (inclusively) on `\n` and trimming off that `\n` and _optionally also a `\r`_ in the iterator before returning it to us.
