### PR TITLE
Use rustls instead of OpenSSL TLS

### DIFF
--- a/xbuild/Cargo.toml
+++ b/xbuild/Cargo.toml
@@ -29,7 +29,7 @@ mvn = { version = "0.2.0", path = "../mvn" }
 path-slash = "0.2.1"
 plist = "1.3.1"
 quick-xml = { version = "0.26.0", features = ["serialize"] }
-reqwest = { version = "0.11.13", features = ["blocking"] }
+reqwest = { version = "0.11.13", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1.0.151", features = ["derive"] }
 serde_yaml = "0.9.16"
 symlink = "0.1.0"


### PR DESCRIPTION
This allows the release executable to be a single static binary on Linux platforms. Closes #132