### PR TITLE
adb: Drop `-W` (wait for app) from `am start` for faster `--uid` filter

### DIFF
--- a/xbuild/src/devices/adb.rs
+++ b/xbuild/src/devices/adb.rs
@@ -98,7 +98,6 @@ impl Adb {
             .shell(device, None)
             .arg("am")
             .arg("start")
-            .arg("-W")
             .arg("-a")
             .arg("android.intent.action.MAIN")
             .arg("-n")


### PR DESCRIPTION
This effectively reverts commit bf478adbae4e3ece3e5c3f3de85404c88a127593 (#118) without touching code improvements elsewhere.  `-W` makes app start-up significantly slower, sometimes leaving the user wait up to 10 seconds even if the app has already started and crashed without showing any `logcat` output.  It has now become unnecessary since using the app `uid` as filter in #131, which is always available as long as the app is installed and doesn't rely on a running (**before** having crashed!) executable for a process id.
