### PR TITLE
Use `gradle` when the build target is `Aab`

### DIFF
--- a/xbuild/src/command/build.rs
+++ b/xbuild/src/command/build.rs
@@ -29,7 +29,12 @@ pub fn build(env: &BuildEnv) -> Result<()> {
     let bin_target = env.target().platform() != Platform::Android;
     let has_lib = env.root_dir().join("src").join("lib.rs").exists();
     if bin_target || has_lib {
-        if env.target().platform() == Platform::Android && env.config().android().gradle {
+        ensure!(
+            env.target().format() != Format::Aab || env.target().android_gradle,
+            "Android App Bundles (AABs) can currently only be built using `gradle`"
+        );
+
+        if env.target().platform() == Platform::Android && env.target().android_gradle {
             crate::gradle::prepare(env)?;
         }
         for target in env.target().compile_targets() {
@@ -185,7 +190,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                 }
             }
 
-            if env.config().android().gradle {
+            if env.target().android_gradle {
                 crate::gradle::build(env, libraries, &out)?;
                 runner.end_verbose_task();
                 return Ok(());

--- a/xbuild/src/config.rs
+++ b/xbuild/src/config.rs
@@ -430,8 +430,10 @@ pub struct AndroidConfig {
     pub manifest: AndroidManifest,
     #[serde(default)]
     pub dependencies: Vec<String>,
+    /// Defaults to [`false`], but uses [`true`] when the user builds a format that requires
+    /// `gradle` (i.e. [`Format::Aab`]).
     #[serde(default)]
-    pub gradle: bool,
+    pub gradle: Option<bool>,
     #[serde(default)]
     pub wry: bool,
     #[serde(default)]

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::cargo::{Cargo, CargoBuild, CrateType};
 use crate::config::Config;
 use crate::devices::Device;
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use clap::Parser;
 use std::path::{Path, PathBuf};
 use xcommon::Signer;
@@ -466,8 +466,18 @@ impl BuildTargetArgs {
         } else if store == Some(Store::Play) {
             Format::Aab
         } else {
-            Format::platform_default(platform, opt, config.android().gradle)
+            let user_wants_gradle = config.android().gradle.unwrap_or(false);
+            Format::platform_default(platform, opt, user_wants_gradle)
         };
+
+        let android_gradle = config.android().gradle.unwrap_or(format == Format::Aab);
+
+        ensure!(
+            // This fails if the format is Aab while `gradle == Some(false)`
+            format != Format::Aab || android_gradle,
+            "Android App Bundles (AABs) can currently only be built using `gradle`"
+        );
+
         let provisioning_profile = if let Some(profile) = self.provisioning_profile {
             anyhow::ensure!(
                 profile.exists(),
@@ -492,6 +502,7 @@ impl BuildTargetArgs {
             signer,
             provisioning_profile,
             api_key,
+            android_gradle,
         })
     }
 }
@@ -507,6 +518,7 @@ pub struct BuildTarget {
     signer: Option<Signer>,
     provisioning_profile: Option<Vec<u8>>,
     api_key: Option<PathBuf>,
+    android_gradle: bool,
 }
 
 impl BuildTarget {


### PR DESCRIPTION
Depends on #140 to prevent conflicts

Instead of explicitly requiring `gradle: true` in the manifest, enable it by default when the (implicit or explicit!) output package format is `Aab` for convenience, as there is currently no way to select the `gradle` backend via command line parameters and hardcoding it in `manifest.yaml` makes it inconvenient to build `Apk`s with the "native" builtin backend.

Also insert validation in case the user explicitly inserts `gradle: false` but tries to build `Aab`s.  The default for releases is still `Aab` if there is an explicit `gradle: true`, but an `Apk` is built otherwise.
