### PR TITLE
Support cross-compiling to aarch64 on MSVC

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install rust toolchain
       uses: hecrj/setup-rust-action@v1
     - run: cargo install xwin
-    - run: xwin --accept-license splat --output Windows.sdk
+    - run: xwin --accept-license --arch aarch64,x86_64 splat --output Windows.sdk
     - run: tar --zstd -cf Windows.sdk.tar.zst Windows.sdk
     - run: gh release upload $TAG Windows.sdk.tar.zst -R rust-mobile/xbuild
       env:

--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -317,9 +317,13 @@ impl CargoBuild {
         self.add_include_dir(&path.join("sdk").join("include").join("um"));
         self.add_include_dir(&path.join("sdk").join("include").join("ucrt"));
         self.add_include_dir(&path.join("sdk").join("include").join("shared"));
-        self.add_lib_dir(&path.join("crt").join("lib").join("x86_64"));
-        self.add_lib_dir(&path.join("sdk").join("lib").join("um").join("x86_64"));
-        self.add_lib_dir(&path.join("sdk").join("lib").join("ucrt").join("x86_64"));
+        let arch_folder = match self.target.arch() {
+            crate::Arch::Arm64 => "aarch64",
+            crate::Arch::X64 => "x86_64",
+        };
+        self.add_lib_dir(&path.join("crt").join("lib").join(arch_folder));
+        self.add_lib_dir(&path.join("sdk").join("lib").join("um").join(arch_folder));
+        self.add_lib_dir(&path.join("sdk").join("lib").join("ucrt").join(arch_folder));
         Ok(())
     }
 


### PR DESCRIPTION
Ship the binaries in our minimal prebuilt package and generalize the library paths to support `aarch64-pc-windows-msvc` cross-compiles.

# TODO

Check if this is also used when on Windows, but on the "wrong" architecture.
