### PR TITLE
cargo: Use the right LLVM tools and arguments for MSVC cross-compilation

### DIFF
--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -306,17 +306,14 @@ impl CargoBuild {
 
     pub fn use_windows_sdk(&mut self, path: &Path) -> Result<()> {
         let path = dunce::canonicalize(path)?;
-        self.cfg_tool(Tool::Cc, "clang");
-        self.cfg_tool(Tool::Cxx, "clang++");
+        self.cfg_tool(Tool::Cc, "clang-cl");
+        self.cfg_tool(Tool::Cxx, "clang-cl");
         self.cfg_tool(Tool::Ar, "llvm-lib");
-        self.cfg_tool(Tool::Linker, "rust-lld");
-        self.use_ld("lld-link");
-        self.add_target_feature("+crt-static");
-        self.add_cxxflag("-stdlib=libc++");
-        self.add_include_dir(&path.join("crt").join("include"));
-        self.add_include_dir(&path.join("sdk").join("include").join("um"));
-        self.add_include_dir(&path.join("sdk").join("include").join("ucrt"));
-        self.add_include_dir(&path.join("sdk").join("include").join("shared"));
+        self.cfg_tool(Tool::Linker, "rust-lld"); // Rust defaults to link.exe, use its rust-lld binary instead
+        self.add_msvc_include_dir(&path.join("crt").join("include"));
+        self.add_msvc_include_dir(&path.join("sdk").join("include").join("um"));
+        self.add_msvc_include_dir(&path.join("sdk").join("include").join("ucrt"));
+        self.add_msvc_include_dir(&path.join("sdk").join("include").join("shared"));
         self.add_lib_dir(&path.join("crt").join("lib").join("x86_64"));
         self.add_lib_dir(&path.join("sdk").join("lib").join("um").join("x86_64"));
         self.add_lib_dir(&path.join("sdk").join("lib").join("ucrt").join("x86_64"));
@@ -437,6 +434,10 @@ impl CargoBuild {
 
     pub fn add_include_dir(&mut self, path: &Path) {
         self.c_flags.push_str(&format!("-I{} ", path.display()));
+    }
+
+    pub fn add_msvc_include_dir(&mut self, path: &Path) {
+        self.c_flags.push_str(&format!("-imsvc{} ", path.display()));
     }
 
     pub fn set_sysroot(&mut self, path: &Path) {


### PR DESCRIPTION
`xbuild` uses the headers from `xwin` to support cross-compiling, but doesn't fully replicate the other setup steps that it proposes to provide a valid and working cross-compilation setup to MSVC.  We need to make the following changes:

- `clang-cl` must be used (a `clang` driver with `cl.exe` interface), as all native projects will call `CC`/`CXX` with flags that are only compatible with `cl.exe`;
- `-I` does not seem to set up the system headers correctly, for this `-imsvc` should be used;
- Remove `-Clink-arg=-fuse-ld=lld-link` because we have already selected a linker for Rust with the `LINKER` env var (see warning below). We might instead want to set it in `C(XX)FLAGS` so that when a native crate uses `CC`/`CXX` to link libraries, it can use `lld-link` instead of (probably, like `cargo`/`rustc` when `LINKER` is unsed) using `link.exe` by default;
- Unset forced static CRT and `stdlib=libc++` selection, as these don't appear to ever be needed, and cause some builds to fail (when crates are changing these config options themselves?):

      = note: rust-lld: warning: ignoring unknown argument '-fuse-ld=lld-link'
              rust-lld: error: /failifmismatch: mismatch detected for 'RuntimeLibrary':
              >>> libbasis_universal_sys-4f5abd4a27e6aa13.rlib(basisu_resample_filters.o) has value MT_StaticRelease
              >>> libintel_tex_2-6d9bd3438efd06d9.rlib(ispc_texcomp_astc.o) has value MD_DynamicRelease

