### PR TITLE
cargo: Forward `cflags` to `bindgen` via `BINDGEN_EXTRA_CLANG_ARGS`

### DIFF
--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -387,10 +387,21 @@ impl CargoBuild {
     fn cargo_target_env(&mut self, name: &str, value: &str) {
         if let Some(triple) = self.triple {
             let utarget = triple.replace('-', "_");
-            let env = format!("CARGO_TARGET_{}_{}", &utarget, name);
+            let env = format!("CARGO_TARGET_{}_{}", utarget, name);
             self.cmd.env(env.to_uppercase(), value);
         } else {
             self.cmd.env(name, value);
+        }
+    }
+
+    /// Configures a cargo target specific environment variable.
+    fn bindgen_env(&mut self, value: &str) {
+        if let Some(triple) = self.triple {
+            let utarget = triple.replace('-', "_");
+            let env = format!("BINDGEN_EXTRA_CLANG_ARGS_{}", utarget);
+            self.cmd.env(env, value);
+        } else {
+            self.cmd.env("BINDGEN_EXTRA_CLANG_ARGS", value);
         }
     }
 
@@ -465,6 +476,7 @@ impl CargoBuild {
 
     pub fn exec(mut self) -> Result<()> {
         self.cargo_target_env("RUSTFLAGS", &self.rust_flags.clone());
+        self.bindgen_env(&self.c_flags.clone());
         self.cc_triple_env("CFLAGS", &self.c_flags.clone());
         // These strings already end with a space if they're non-empty:
         self.cc_triple_env("CXXFLAGS", &format!("{}{}", self.c_flags, self.cxx_flags));


### PR DESCRIPTION
When a crate invokes `bindgen` through a `build.rs` script to generate Rust code files, it should be using the headers that target Android rather than system headers.  The include paths for these are already set up in the `cflags` that we pass to `cc-rs` (for `clang`), and can be trivially reused for `bindgen`'s `clang`.
