### PR TITLE
Add missing "path context" for more IO failures

### DIFF
--- a/xbuild/src/command/build.rs
+++ b/xbuild/src/command/build.rs
@@ -149,7 +149,12 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                                 .package_root()
                                 .join(runtime_lib_path)
                                 .join(target.android_abi().android_abi());
-                            let entries = std::fs::read_dir(abi_dir)?;
+                            let entries = std::fs::read_dir(&abi_dir).with_context(|| {
+                                format!(
+                                    "Runtime libraries for current ABI not found at `{}`",
+                                    abi_dir.display()
+                                )
+                            })?;
                             for entry in entries {
                                 let entry = entry?;
                                 let path = entry.path();

--- a/xcommon/src/lib.rs
+++ b/xcommon/src/lib.rs
@@ -23,7 +23,10 @@ pub struct Scaler {
 
 impl Scaler {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let img = ImageReader::open(path)?.decode()?;
+        let path = path.as_ref();
+        let img = ImageReader::open(path)
+            .with_context(|| format!("Scaler failed to open image at `{}`", path.display()))?
+            .decode()?;
         let (width, height) = img.dimensions();
         anyhow::ensure!(width == height, "expected width == height");
         anyhow::ensure!(width >= 512, "expected icon of at least 512x512 px");


### PR DESCRIPTION
Whenever a _user configurable_ path is not found, this currently prints a useless "File not found" without any additional context _which_ path was attempted nor where it was configured.  By explaining what we're doing in the error messages, users are more likely to know what and where to correct.
