### PR TITLE
Fix `lldb-server` not copied to target device

### DIFF
--- a/xbuild/src/devices/adb.rs
+++ b/xbuild/src/devices/adb.rs
@@ -302,12 +302,17 @@ impl Adb {
             .arg("700")
             .arg(&dest)
             .status()?;*/
+        let lldb_device_path = Path::new("./lldb-server");
         let mut lldb_server = self
             .shell(device, None)
             .arg("cd")
             .arg("/data/local/tmp")
             .arg("&&")
-            .arg("./lldb-server")
+            .arg("chmod")
+            .arg("777")
+            .arg(lldb_device_path)
+            .arg("&&")
+            .arg(lldb_device_path)
             .arg("platform")
             .arg("--listen")
             .arg("*:10086")

--- a/xbuild/src/devices/adb.rs
+++ b/xbuild/src/devices/adb.rs
@@ -277,7 +277,7 @@ impl Adb {
         Ok(Path::new(std::str::from_utf8(&output.stdout)?.trim()).to_path_buf())
     }*/
 
-    pub fn lldb(&self, device: &str, lldb_server: &Path, executable: &Path) -> Result<()> {
+    pub fn lldb(&self, device: &str, executable: &Path, lldb_server: &Path) -> Result<()> {
         /*let package = env.manifest().android().package.as_ref().unwrap();
         let app_dir = self.app_dir(device, package)?;
         self.shell(device, Some(package))


### PR DESCRIPTION
When running the `lldb` command, `lldb-server` wouldn't be copied to the device, no matter if this was present on the `xbuild` host desktop or not. This would result in `lldb` saying it's not able to connect through the target port, but the warning that the copy failed because the executable wasn't present on the source desktop path was the real issue.

Some arguments were flipped quite some time ago, which caused it to always use the wrong path. Also, by default it would not allow for execution so added a `chmod 777` to complete. Running this with on a clean device now correctly launches `lldb` from start to finish. Note that it is strange that the respective `push` commands don't indicate a failure, despite the source file (i.e. the `lldb-server` executable) not being present. After these changes `x lldb` is able to start successfully from a clean slate.

The `lldb` command still has issues for us as this results in it throwing this error:

```
thread #1, name = '{...}', stop reason = signal SIGSEGV: address access protected (fault address: 0x7fed809000)
    frame #0: 0x0000007fed809000 {...}.so
->  0x7fed809000: .long  0x464c457f                ; unknown opcode
    0x7fed809004: .long  0x00010102                ; unknown opcode
    0x7fed809008: udf    #0x0
    0x7fed80900c: udf    #0x0
```

This despite running with `debuggable: true` in our Manifest. Not sure if it's related directly to the `lldb` command's setup. Maybe someone else can chip in on what could be the issue for the above?

I still think the changes from this PR can go in though.