### PR TITLE
Fix workspace members manifest search

### DIFF
--- a/xbuild/src/cargo/manifest.rs
+++ b/xbuild/src/cargo/manifest.rs
@@ -40,6 +40,9 @@ impl Manifest {
         for member in &workspace.members {
             for manifest_dir in glob::glob(workspace_root.join(member).to_str().unwrap())? {
                 let manifest_dir = manifest_dir?;
+                if !manifest_dir.is_dir() {
+                    continue;
+                }
                 let manifest_path = manifest_dir.join("Cargo.toml");
                 let manifest = Manifest::parse_from_toml(&manifest_path).with_context(|| {
                     format!(


### PR DESCRIPTION
Workspaces with glob member paths can match files too, cargo metadata ignores file matches, this behavior is now replicated in `Manifest::members`.

Fixes #183