### PR TITLE
Fix missing `"exe"` variant and copy-paste mistakes in `Format`

### DIFF
--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -167,17 +167,18 @@ impl std::fmt::Display for Format {
 impl std::str::FromStr for Format {
     type Err = anyhow::Error;
 
-    fn from_str(arch: &str) -> Result<Self> {
-        Ok(match arch {
+    fn from_str(format: &str) -> Result<Self> {
+        Ok(match format {
             "aab" => Self::Aab,
             "apk" => Self::Apk,
             "appbundle" => Self::Appbundle,
             "appdir" => Self::Appdir,
             "appimage" => Self::Appimage,
             "dmg" => Self::Dmg,
+            "exe" => Self::Exe,
             "ipa" => Self::Ipa,
             "msix" => Self::Msix,
-            _ => anyhow::bail!("unsupported arch {}", arch),
+            _ => anyhow::bail!("unsupported format {}", format),
         })
     }
 }


### PR DESCRIPTION
Fixes #194, @SolidTux please test this.

Passing `--format exe` would fail, complaining that the "arch" `exe` is not supported.  Copy-paste mistakes from "arch" to "format" aside, the `"exe"` string wasn't in the match arm (missed in da16695c18020216a6bed3993c1a77875f94ac57).

Realistically, as we are already utilizing `clap`, we should remove all this error-prone (proven by this example) open-coding of broken parsers and utilize their derives to automatically generate conversion functions.

This should at the same time assist us in generating help files, as the hardcoded documentation for `--format` currently states that `exe` is a supported value.
