### PR TITLE
added arm 32bit support

### DIFF
--- a/apk/src/utils.rs
+++ b/apk/src/utils.rs
@@ -4,9 +4,10 @@ use anyhow::{Context, Result};
 #[repr(u8)]
 pub enum Target {
     ArmV7a = 1,
-    Arm64V8a = 2,
-    X86 = 3,
-    X86_64 = 4,
+    Armeabi = 2,
+    Arm64V8a = 3,
+    X86 = 4,
+    X86_64 = 5,
 }
 
 impl Target {
@@ -14,6 +15,7 @@ impl Target {
     pub fn android_abi(self) -> &'static str {
         match self {
             Self::Arm64V8a => "arm64-v8a",
+            Self::Armeabi => "armeabi",
             Self::ArmV7a => "armeabi-v7a",
             Self::X86 => "x86",
             Self::X86_64 => "x86_64",

--- a/xbuild/src/devices/imd.rs
+++ b/xbuild/src/devices/imd.rs
@@ -127,6 +127,9 @@ impl IMobileDevice {
     pub fn arch(&self, device: &str) -> Result<Arch> {
         match self.getkey(device, "CPUArchitecture")?.as_str() {
             "arm64" | "arm64e" => Ok(Arch::Arm64),
+            "armv7" => Ok(Arch::Armv7),
+            "arm" => Ok(Arch::Arm),
+            "x86_64" => Ok(Arch::X64),
             arch => anyhow::bail!("unsupported arch {}", arch),
         }
     }

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -92,7 +92,8 @@ impl std::str::FromStr for Platform {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Arch {
-    //Arm,
+    Armv7,
+    Arm,
     Arm64,
     X64,
     //X86,
@@ -113,7 +114,8 @@ impl Arch {
 impl std::fmt::Display for Arch {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            //Self::Arm => write!(f, "arm"),
+            Self::Armv7 => write!(f, "armv7"),
+            Self::Arm => write!(f, "arm"),
             Self::Arm64 => write!(f, "arm64"),
             Self::X64 => write!(f, "x64"),
             //Self::X86 => write!(f, "x86"),
@@ -126,7 +128,8 @@ impl std::str::FromStr for Arch {
 
     fn from_str(arch: &str) -> Result<Self> {
         Ok(match arch {
-            //"arm" => Self::Arm,
+            "arm" => Self::Arm,
+            "armv7" => Self::Armv7,
             "arm64" => Self::Arm64,
             "x64" => Self::X64,
             //"x86" => Self::X86,
@@ -281,6 +284,8 @@ impl CompileTarget {
     pub fn android_abi(self) -> apk::Target {
         assert_eq!(self.platform(), Platform::Android);
         match self.arch() {
+            Arch::Armv7 => apk::Target::ArmV7a,
+            Arch::Arm => apk::Target::Armeabi,
             Arch::Arm64 => apk::Target::Arm64V8a,
             Arch::X64 => apk::Target::X86_64,
         }
@@ -291,7 +296,8 @@ impl CompileTarget {
         assert_eq!(self.platform(), Platform::Android);
         match self.arch() {
             Arch::Arm64 => "aarch64-linux-android",
-            //Arch::Arm => "arm-linux-androideabi",
+            Arch::Arm => "arm-linux-androideabi",
+            Arch::Armv7 => "armv7-linux-androideabi",
             //Arch::X86 => "i686-linux-android",
             Arch::X64 => "x86_64-linux-android",
         }
@@ -300,6 +306,8 @@ impl CompileTarget {
     pub fn rust_triple(self) -> Result<&'static str> {
         Ok(match (self.arch, self.platform) {
             (Arch::Arm64, Platform::Android) => "aarch64-linux-android",
+            (Arch::Armv7, Platform::Android) => "armv7-linux-androideabi",
+            (Arch::Arm, Platform::Android) => "arm-linux-androideabi",
             (Arch::Arm64, Platform::Ios) => "aarch64-apple-ios",
             (Arch::Arm64, Platform::Linux) => "aarch64-unknown-linux-gnu",
             (Arch::Arm64, Platform::Macos) => "aarch64-apple-darwin",
@@ -381,7 +389,7 @@ pub struct BuildTargetArgs {
     #[clap(long, conflicts_with = "device")]
     platform: Option<Platform>,
     /// Build artifacts for target arch. Can be one of
-    /// `arm64` or `x64`.
+    /// `arm`, `armv7` `arm64` or `x64`.
     #[clap(long, requires = "platform")]
     arch: Option<Arch>,
     /// Build artifacts for target device. To find the device


### PR DESCRIPTION
I think now builds for 32-bit ARMv7 Android (armeabi-v7a) is possible, I tested it manually, so yes, testing is missing still. Use `x build --platform android --arch armv7` or `--arch arm` which will use androideabi.

This is my first ever contribution, So yes, I don't know what I'm doing.

let me know what I'm doing wrong so I can make sure everything is good to go.