### PR TITLE
CI: Remove `libgcc.a` linker workaround from repackaged NDK

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -23,11 +23,6 @@ jobs:
     - run: cp -r $CLANG/lib/linux/x86_64/* Android.ndk/usr/lib/x86_64-linux-android/
     - run: cp -r $CLANG/lib/linux/i386/* Android.ndk/usr/lib/i686-linux-android/
 
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/aarch64-linux-android/libgcc.a
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/arm-linux-androideabi/libgcc.a
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/x86_64-linux-android/libgcc.a
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/i686-linux-android/libgcc.a
-
     - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
     - run: gh release upload $TAG Android.ndk.tar.zst -R ${{ github.repository }}
       env:


### PR DESCRIPTION
[Rust 1.68 is now targeting NDK r25] instead of r17 and no longer tries to forcibly link against `libgcc.a`, which was removed since NDK r23 in favour of [only needing to link against `libunwind`].  Since this Rust release is over 1.5 years old, assume everyone is using at least 1.68 and drop the workaround from our repackaged NDK release.

[Rust 1.68 is now targeting NDK r25]: https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#other-changes
[only needing to link against `libunwind`]: https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html