### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: echo "TOOLCHAIN=$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64" >> $GITHUB_ENV
-    - run: ls $TOOLCHAIN/lib64/clang | xargs -0 printf "CLANG_VERSION=%s" >> $GITHUB_ENV
-    - run: echo "CLANG=$TOOLCHAIN/lib64/clang/$CLANG_VERSION" >> $GITHUB_ENV
+    - run: ls $TOOLCHAIN/lib/clang | xargs -0 printf "CLANG_VERSION=%s" >> $GITHUB_ENV
+    - run: echo "CLANG=$TOOLCHAIN/lib/clang/$CLANG_VERSION" >> $GITHUB_ENV
 
     - run: echo $ANDROID_NDK_LATEST_HOME
     - run: echo $CLANG_VERSION

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -23,11 +23,6 @@ jobs:
     - run: cp -r $CLANG/lib/linux/x86_64/* Android.ndk/usr/lib/x86_64-linux-android/
     - run: cp -r $CLANG/lib/linux/i386/* Android.ndk/usr/lib/i686-linux-android/
 
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/aarch64-linux-android/libgcc.a
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/arm-linux-androideabi/libgcc.a
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/x86_64-linux-android/libgcc.a
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/i686-linux-android/libgcc.a
-
     - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
     - run: gh release upload $TAG Android.ndk.tar.zst -R ${{ github.repository }}
       env:

--- a/xbuild/src/download.rs
+++ b/xbuild/src/download.rs
@@ -193,7 +193,7 @@ impl WorkItem {
 impl WorkItem {
     const ORG: &'static str = "rust-mobile";
     const REPO: &'static str = "xbuild";
-    const VERSION: &'static str = "v0.1.0+3";
+    const VERSION: &'static str = "v0.2.1-alpha";
 
     pub fn xbuild_release(output: PathBuf, artifact: &str) -> Self {
         Self::github_release(output, Self::ORG, Self::REPO, Self::VERSION, artifact)


### PR DESCRIPTION
- **CI: Remove `libgcc.a` linker workaround from repackaged NDK**
- **Prepare 0.2.1 release**
