### PR TITLE
template: Update to `dioxus 0.4`/`wry 0.28` with `libwebkit2gtk-4.1-dev`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,14 @@ jobs:
 
     - name: install linux dependencies
       if: ${{ matrix.host == 'ubuntu-latest' }}
-      run: sudo apt-get update && sudo apt-get install libwebkit2gtk-4.0-dev libgtk-3-dev squashfs-tools
+      run: sudo apt-get update && sudo apt-get install libwebkit2gtk-4.1-dev libgtk-3-dev squashfs-tools
 
     - name: create project
       run: ./x new template
 
-    # only linux can target linux as it is not clear what that even is exactly
-    # glibc/musl gtk/qt x11/wayland
-    # windows doesn't support posix symlinks so can't cross compile to macos/ios
+    # Only linux can target linux as it is not clear what that even is exactly
+    # (glibc/musl GTK/QT X11/Wayland).
+    # Windows doesn't support posix symlinks so can't cross compile to MacOS/iOS.
     - name: build project
       if: >
         !(matrix.host == 'macos-latest' && matrix.target.platform == 'linux' ||

--- a/xbuild/template/Cargo_toml
+++ b/xbuild/template/Cargo_toml
@@ -8,10 +8,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0.68"
-dioxus = "0.3.1"
+dioxus = "0.4"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-dioxus-desktop = "0.3.0"
+dioxus-desktop = "0.4"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.11.1"
@@ -21,5 +21,5 @@ paste = "1.0.11"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 console_error_panic_hook = "0.1.7"
-dioxus-web = "0.3.0"
+dioxus-web = "0.4"
 wasm-logger = "0.2.0"


### PR DESCRIPTION
We've been getting deprecation warnings in the CI that Ubuntu 22.04 is going to be replaced with Ubuntu 24.04 soon for the `ubuntu-latest` image.

That happened just a few days ago, and now the CI complains that `libwebkit2gtk-4.0-dev` can no longer be found in Ubuntu Noble's APT repositories.  We have to upgrade to `4.1`, which can be achieved by using at least `wry 0.25`: https://github.com/tauri-apps/wry/commit/c5f3b36

This is used by `dioxus 0.4`, which is the target of this upgrade.  As I am not a user of any of the `wry`/`dioxus` functionality inside `xbuild` (and if not for me, it doesn't look like anyone else is maintaining or caring about this either), I kept this upgrade as small as possible and didn't upgrade to `dioxus 0.6.1` (the latest as of writing) which might incur more breaking changes and require testing which I'm not inclined to perform.  All I really need is the CI to succeed again :)
