### PR TITLE
CI: Bump `upload-artifact` / `download-artifact` to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: hecrj/setup-rust-action@v1
     - run: cargo install --path xbuild --root .
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.host }}-x
         path: bin/x${{ matrix.host == 'windows-latest' && '.exe' || '' }}
@@ -64,7 +64,7 @@ jobs:
         rust-version: stable
 
     - name: install x
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ matrix.host }}-x
     - run: chmod +x ./x


### PR DESCRIPTION
Starting today (January 30th, 2025), v3 is no longer available to use after a long deprecation period: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
