### PR TITLE
Support new resource table fields and flags in Android 35 `android.jar`

### DIFF
--- a/apk/src/compiler/mod.rs
+++ b/apk/src/compiler/mod.rs
@@ -2,8 +2,8 @@ use std::num::NonZeroU8;
 
 use crate::manifest::AndroidManifest;
 use crate::res::{
-    Chunk, ResTableConfig, ResTableEntry, ResTableHeader, ResTablePackageHeader,
-    ResTableTypeHeader, ResTableTypeSpecHeader, ResTableValue, ResValue, ScreenType,
+    Chunk, ResTableConfig, ResTableEntry, ResTableHeader, ResTablePackageHeader, ResTableValue,
+    ResValue, ScreenType,
 };
 use anyhow::Result;
 
@@ -44,15 +44,7 @@ pub fn compile_mipmap<'a>(package_name: &str, name: &'a str) -> Result<Mipmap<'a
                 vec![
                     Chunk::StringPool(vec!["mipmap".to_string()], vec![]),
                     Chunk::StringPool(vec!["icon".to_string()], vec![]),
-                    Chunk::TableTypeSpec(
-                        ResTableTypeSpecHeader {
-                            id: NonZeroU8::new(1).unwrap(),
-                            res0: 0,
-                            res1: 0,
-                            entry_count: 1,
-                        },
-                        vec![256],
-                    ),
+                    Chunk::TableTypeSpec(NonZeroU8::new(1).unwrap(), vec![256]),
                     mipmap_table_type(NonZeroU8::new(1).unwrap(), 160, 0),
                     mipmap_table_type(NonZeroU8::new(1).unwrap(), 240, 1),
                     mipmap_table_type(NonZeroU8::new(1).unwrap(), 320, 2),
@@ -66,30 +58,23 @@ pub fn compile_mipmap<'a>(package_name: &str, name: &'a str) -> Result<Mipmap<'a
 }
 
 fn mipmap_table_type(type_id: NonZeroU8, density: u16, string_id: u32) -> Chunk {
-    Chunk::TableType(
-        ResTableTypeHeader {
-            id: type_id,
-            res0: 0,
-            res1: 0,
-            entry_count: 1,
-            entries_start: 88,
-            config: ResTableConfig {
-                size: 28 + 36,
-                imsi: 0,
-                locale: 0,
-                screen_type: ScreenType {
-                    orientation: 0,
-                    touchscreen: 0,
-                    density,
-                },
-                input: 0,
-                screen_size: 0,
-                version: 4,
-                unknown: vec![0; 36],
+    Chunk::TableType {
+        type_id,
+        config: ResTableConfig {
+            size: 28 + 36,
+            imsi: 0,
+            locale: 0,
+            screen_type: ScreenType {
+                orientation: 0,
+                touchscreen: 0,
+                density,
             },
+            input: 0,
+            screen_size: 0,
+            version: 4,
+            unknown: vec![0; 36],
         },
-        vec![0],
-        vec![Some(ResTableEntry {
+        entries: vec![Some(ResTableEntry {
             size: 8,
             flags: 0,
             key: 0,
@@ -100,7 +85,7 @@ fn mipmap_table_type(type_id: NonZeroU8, density: u16, string_id: u32) -> Chunk 
                 data: string_id,
             }),
         })],
-    )
+    }
 }
 
 pub struct Mipmap<'a> {

--- a/apk/src/compiler/mod.rs
+++ b/apk/src/compiler/mod.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU8;
+
 use crate::manifest::AndroidManifest;
 use crate::res::{
     Chunk, ResTableConfig, ResTableEntry, ResTableHeader, ResTablePackageHeader,
@@ -44,18 +46,18 @@ pub fn compile_mipmap<'a>(package_name: &str, name: &'a str) -> Result<Mipmap<'a
                     Chunk::StringPool(vec!["icon".to_string()], vec![]),
                     Chunk::TableTypeSpec(
                         ResTableTypeSpecHeader {
-                            id: 1,
+                            id: NonZeroU8::new(1).unwrap(),
                             res0: 0,
                             res1: 0,
                             entry_count: 1,
                         },
                         vec![256],
                     ),
-                    mipmap_table_type(1, 160, 0),
-                    mipmap_table_type(1, 240, 1),
-                    mipmap_table_type(1, 320, 2),
-                    mipmap_table_type(1, 480, 3),
-                    mipmap_table_type(1, 640, 4),
+                    mipmap_table_type(NonZeroU8::new(1).unwrap(), 160, 0),
+                    mipmap_table_type(NonZeroU8::new(1).unwrap(), 240, 1),
+                    mipmap_table_type(NonZeroU8::new(1).unwrap(), 320, 2),
+                    mipmap_table_type(NonZeroU8::new(1).unwrap(), 480, 3),
+                    mipmap_table_type(NonZeroU8::new(1).unwrap(), 640, 4),
                 ],
             ),
         ],
@@ -63,7 +65,7 @@ pub fn compile_mipmap<'a>(package_name: &str, name: &'a str) -> Result<Mipmap<'a
     Ok(Mipmap { name, chunk })
 }
 
-fn mipmap_table_type(type_id: u8, density: u16, string_id: u32) -> Chunk {
+fn mipmap_table_type(type_id: NonZeroU8, density: u16, string_id: u32) -> Chunk {
     Chunk::TableType(
         ResTableTypeHeader {
             id: type_id,

--- a/apk/src/compiler/table.rs
+++ b/apk/src/compiler/table.rs
@@ -91,8 +91,11 @@ impl<'a> Package<'a> {
 
     fn lookup_type(&self, id: NonZeroU8) -> Result<Type<'a>> {
         for chunk in self.chunks {
-            if let Chunk::TableType(header, _offsets, entries) = chunk {
-                if header.id == id {
+            if let Chunk::TableType {
+                type_id, entries, ..
+            } = chunk
+            {
+                if *type_id == id {
                     return Ok(Type {
                         package: self.id,
                         id,

--- a/apk/src/compiler/table.rs
+++ b/apk/src/compiler/table.rs
@@ -191,6 +191,7 @@ pub struct Table {
 
 impl Table {
     pub fn import_apk(&mut self, apk: &Path) -> Result<()> {
+        tracing::trace!("Parse `resources.arsc` chunk from `{apk:?}`");
         let resources = xcommon::extract_zip_file(apk, "resources.arsc")?;
         let chunk = Chunk::parse(&mut Cursor::new(resources))?;
         self.import_chunk(&chunk);
@@ -218,7 +219,7 @@ impl Table {
         }
     }
 
-    fn lookup_package(&self, id: u8) -> Result<Package> {
+    fn lookup_package(&self, id: u8) -> Result<Package<'_>> {
         for package in &self.packages {
             if let Chunk::TablePackage(header, chunks) = package {
                 if header.id == id as u32 {
@@ -229,7 +230,7 @@ impl Table {
         anyhow::bail!("failed to locate package {}", id);
     }
 
-    pub fn entry_by_ref(&self, r: Ref) -> Result<Entry> {
+    pub fn entry_by_ref(&self, r: Ref) -> Result<Entry<'_>> {
         let id = self.lookup_package_id(r.package)?;
         let package = self.lookup_package(id)?;
         let id = package.lookup_type_id(r.ty)?;

--- a/apk/src/res.rs
+++ b/apk/src/res.rs
@@ -426,8 +426,8 @@ pub struct ResTableTypeSpecHeader {
     pub id: NonZeroU8,
     /// Must be 0.
     pub res0: u8,
-    /// Must be 0.
-    pub res1: u16,
+    /// Used to be reserved, if >0 specifies the number of `ResTable_type` entries for this spec.
+    pub types_count: u16,
     /// Number of u32 entry configuration masks that follow.
     pub entry_count: u32,
 }
@@ -440,16 +440,12 @@ impl ResTableTypeSpecHeader {
             res0, 0,
             "ResTableTypeSpecHeader reserved field 0 should be 0"
         );
-        let res1 = r.read_u16::<LittleEndian>()?;
-        debug_assert_eq!(
-            res1, 0,
-            "ResTableTypeSpecHeader reserved field 1 should be 0"
-        );
+        let types_count = r.read_u16::<LittleEndian>()?;
         let entry_count = r.read_u32::<LittleEndian>()?;
         Ok(Self {
             id,
             res0,
-            res1,
+            types_count,
             entry_count,
         })
     }
@@ -457,7 +453,7 @@ impl ResTableTypeSpecHeader {
     pub fn write(&self, w: &mut impl Write) -> Result<()> {
         w.write_u8(self.id.get())?;
         w.write_u8(self.res0)?;
-        w.write_u16::<LittleEndian>(self.res1)?;
+        w.write_u16::<LittleEndian>(self.types_count)?;
         w.write_u32::<LittleEndian>(self.entry_count)?;
         Ok(())
     }
@@ -1362,7 +1358,7 @@ impl Chunk {
                 let type_spec_header = ResTableTypeSpecHeader {
                     id: *type_id,
                     res0: 0,
-                    res1: 0,
+                    types_count: 0,
                     entry_count: type_spec.len() as u32,
                 };
                 type_spec_header.write(w)?;

--- a/pri/src/resource_map.rs
+++ b/pri/src/resource_map.rs
@@ -220,18 +220,3 @@ pub enum ResourceValueType {
     AsciiPath,
     Utf8Path,
 }
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct CandidateSet {
-    pub resource_map_item: u32,
-    pub decision_index: u16,
-    pub candidates: Vec<Candidate>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct Candidate {
-    pub qualifier_set: u16,
-    pub ty: ResourceValueType,
-    pub data_item_section: u16,
-    pub data_item_index: u16,
-}


### PR DESCRIPTION
Bumping the `target_sdk_version` to `35` results in hitting random asserts inside the `ResTable` parser. Digging further shows that the parser wasn't that robust after all and happily ignored new fields and flags which should have affected how certain elements are parsed. New changes that Android made since 33:

- `SPARSE` lists for `Type` chunk, instead of storing large arrays with many `None` elements;
- reserved field 1 in `TypeSpec` is now `types_count`;
- 16-bit offset indexing for `Type` chunk;
  - This offset handling was previously ignored because every element "just so happened to be" tightly packed after the offset list, sequential and with no padding in between - those assumptions are also no longer true now;
- `COMPACT` `Type` `Entry`s are now used for 4-byte values.

Note that this PR only marginally tries to remove data-representation-specific pieces from the public `Chunks` API. Callers will still have to guess a few fields that really should be handled internally, but since none of this is really actively used internally I did not bother. `fn compile_mipmap()` seems to spit out mostly bogus though, specifically for `ResTablePackageHeader`.

The existing tests already cover building and then parsing the table again, and also test all installed SDKs which happen to be the full `28..=35` range on my machine; all succeed successfully.